### PR TITLE
SSL and mysql fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 # Flask
 PORT=5000
-CERT_PATH=ssl/example.crt
-KEY_PATH=ssl/example.key
 
 # DB
 MYSQL_ROOT_PASSWORD=banana

--- a/app.py
+++ b/app.py
@@ -7,8 +7,4 @@ os.environ['DEBUG'] = '1'
 app.secret_key = os.environ['SECRET_KEY']
 app.config['SESSION_TYPE'] = 'filesystem'
 
-app.run(host="0.0.0.0", port=int(os.environ['PORT']),
-        debug=False, ssl_context=(
-            os.environ['CERT_PATH'],
-            os.environ['KEY_PATH']
-        ))
+app.run(host="0.0.0.0", port=int(os.environ['PORT']), debug=False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - database
     ports:
-      - "5000:5000"
+      - "80:5000"
 
 networks:
   database:


### PR DESCRIPTION
Some mysql fix and does a really insecure monkey patch to remove https cert verification. As of right now this effectively defaults it back to py2 behavior of not checking. It looks like the issue is known by Flask-OAuthlib, there is a workaround it looks like from this user https://github.com/rg3/youtube-dl/issues/10574#issuecomment-249387863 but for now I just threw in the easy fix. We should properly figure this out with @micheljung before actually deploying